### PR TITLE
feat: Allow shebang option to be a function (#12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ export default {
       // A single or an array of filename patterns. Defaults to ['**/cli.js', '**/bin.js'].
       include: 'out/cli.js'
       // you could also 'exclude' here
-      // or specify a special shebang using the 'shebang' option
+      // or specify a special shebang (or a function returning one) using the 'shebang' option
     }),
   ],
   ...

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,23 +6,26 @@ import { createFilter } from 'rollup-pluginutils';
 interface Options {
   include?: string | string[];
   exclude?: string | string[];
-  shebang?: string;
+  shebang?: string | (() => string);
 }
 
 const plugin: rollup.PluginImpl<Options> = ({
   include = ['**/cli.js', '**/bin.js'],
   exclude,
-  shebang = '#!/usr/bin/env node',
+  shebang: shebangOption = '#!/usr/bin/env node',
 }: Options = {}) => {
   const filter = createFilter(include, exclude) as (fileName: string) => boolean;
 
-  return { name: 'shebang',
+  return {
+    name: 'shebang',
     renderChunk(code, { fileName }, { dir, file, sourcemap }) {
       const outPath = dir ?
         join(dir, fileName) :
         file || fileName;
 
       if (!filter(resolve(outPath))) { return null; }
+
+      const shebang = typeof shebangOption === 'function' ? shebangOption() : shebangOption;
 
       const prefix = `${shebang}
 

--- a/test/_helpers.ts
+++ b/test/_helpers.ts
@@ -1,12 +1,13 @@
 import * as rollup from 'rollup';
 import shebang from '../src/index';
 
-export function bundleSingle() {
+export function bundleSingle(options?: object) {
   return rollup.rollup({
     input: ['./test/fixtures/single.js'],
     plugins: [
       shebang({
         include: 'single.js',
+        ...options,
       }),
     ],
   });

--- a/test/test.ts
+++ b/test/test.ts
@@ -13,3 +13,20 @@ test('should add shebang to rendered chunk', async (t) => {
   t.is(output.fileName, 'single.js');
   t.true(output.code.startsWith('#!/usr/bin/env node'));
 });
+
+test('should add shebang to rendered chunk, using a function', async (t) => {
+  // create a bundle
+  const bundle = await bundleSingle({
+    shebang() {
+      return '#!/usr/bin/env ts-node';
+    },
+  });
+
+  // generate code
+  const { output: [output] } = await bundle.generate({
+    format: 'cjs',
+  });
+
+  t.is(output.fileName, 'single.js');
+  t.true(output.code.startsWith('#!/usr/bin/env ts-node'));
+});


### PR DESCRIPTION
Passing a function as the shebang option we can decide at runtime what shebang should be used. This allows us to e.g. read it from a file first.